### PR TITLE
Fix invoice number uniqueness to per-supplier and prevent PDF collisions

### DIFF
--- a/internal/api/invoices.go
+++ b/internal/api/invoices.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/adamSHA256/tidybill/internal/database/repository"
@@ -171,6 +172,10 @@ func (s *Server) createInvoice(w http.ResponseWriter, r *http.Request) {
 
 	// Create invoice
 	if err := s.invoices.Create(inv); err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			writeError(w, http.StatusConflict, "invoice number already exists: "+inv.InvoiceNumber)
+			return
+		}
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 type Config struct {
@@ -128,8 +129,21 @@ func getDefaultPDFDir() (string, error) {
 	return filepath.Join(home, "Documents", "TidyBill"), nil
 }
 
-func (c *Config) GetPDFPath(invoiceNumber string, year int) string {
-	yearDir := filepath.Join(c.PDFDir, fmt.Sprintf("%d", year))
+func (c *Config) GetPDFPath(invoiceNumber string, year int, supplierName string) string {
+	supplierDir := sanitizeDirName(supplierName)
+	yearDir := filepath.Join(c.PDFDir, supplierDir, fmt.Sprintf("%d", year))
 	os.MkdirAll(yearDir, 0755)
 	return filepath.Join(yearDir, invoiceNumber+".pdf")
+}
+
+func sanitizeDirName(name string) string {
+	replacer := strings.NewReplacer(
+		"/", "_", "\\", "_", ":", "_", "*", "_",
+		"?", "_", "\"", "_", "<", "_", ">", "_", "|", "_",
+	)
+	result := strings.TrimSpace(replacer.Replace(name))
+	if result == "" {
+		return "default"
+	}
+	return result
 }

--- a/internal/database/migrations/004_invoice_number_per_supplier.sql
+++ b/internal/database/migrations/004_invoice_number_per_supplier.sql
@@ -1,0 +1,57 @@
+-- Make invoice_number unique per supplier instead of globally unique.
+-- SQLite can't drop inline UNIQUE constraints, so we recreate the table.
+
+-- Disable foreign keys to prevent CASCADE deletes when dropping the old table.
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE invoices_new (
+    id TEXT PRIMARY KEY,
+    invoice_number TEXT NOT NULL,
+    supplier_id TEXT NOT NULL,
+    customer_id TEXT NOT NULL,
+    bank_account_id TEXT NOT NULL,
+    status TEXT DEFAULT 'draft',
+    issue_date DATE NOT NULL,
+    due_date DATE NOT NULL,
+    paid_date DATE,
+    taxable_date DATE,
+    payment_method TEXT DEFAULT 'bank_transfer',
+    variable_symbol TEXT,
+    currency TEXT DEFAULT 'CZK',
+    exchange_rate REAL DEFAULT 1.0,
+    subtotal REAL DEFAULT 0,
+    vat_total REAL DEFAULT 0,
+    total REAL DEFAULT 0,
+    notes TEXT,
+    internal_notes TEXT,
+    language TEXT DEFAULT 'cs',
+    pdf_path TEXT,
+    template_id TEXT DEFAULT 'default',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (supplier_id) REFERENCES suppliers(id),
+    FOREIGN KEY (customer_id) REFERENCES customers(id),
+    FOREIGN KEY (bank_account_id) REFERENCES bank_accounts(id)
+);
+
+-- Use explicit column names to avoid position-dependent bugs.
+-- (template_id was added via ALTER TABLE in 003, so it's last in the old table.)
+INSERT INTO invoices_new (id, invoice_number, supplier_id, customer_id, bank_account_id,
+    status, issue_date, due_date, paid_date, taxable_date, payment_method, variable_symbol,
+    currency, exchange_rate, subtotal, vat_total, total, notes, internal_notes, language,
+    pdf_path, template_id, created_at, updated_at)
+SELECT id, invoice_number, supplier_id, customer_id, bank_account_id,
+    status, issue_date, due_date, paid_date, taxable_date, payment_method, variable_symbol,
+    currency, exchange_rate, subtotal, vat_total, total, notes, internal_notes, language,
+    pdf_path, template_id, created_at, updated_at
+FROM invoices;
+
+DROP TABLE invoices;
+ALTER TABLE invoices_new RENAME TO invoices;
+
+CREATE UNIQUE INDEX idx_invoices_supplier_number ON invoices(supplier_id, invoice_number);
+CREATE INDEX idx_invoices_status ON invoices(status);
+CREATE INDEX idx_invoices_customer ON invoices(customer_id);
+CREATE INDEX idx_invoices_issue_date ON invoices(issue_date);
+
+PRAGMA foreign_keys = ON;

--- a/internal/database/migrations/005_repair_invoice_columns.sql
+++ b/internal/database/migrations/005_repair_invoice_columns.sql
@@ -1,0 +1,69 @@
+-- Repair data corruption from broken 004 migration.
+-- The broken 004 used "INSERT INTO ... SELECT * FROM" which copies by column
+-- position. Since template_id was added via ALTER TABLE (last position) but
+-- placed before created_at/updated_at in the new table, the three columns
+-- got shifted:
+--   template_id  <- actually holds old created_at
+--   created_at   <- actually holds old updated_at
+--   updated_at   <- actually holds old template_id (e.g. "default")
+--
+-- This migration detects corruption by checking if updated_at contains a
+-- non-datetime string, and swaps the columns back. On clean databases
+-- (fixed 004 or fresh installs), it's a no-op table recreation.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE invoices_repair (
+    id TEXT PRIMARY KEY,
+    invoice_number TEXT NOT NULL,
+    supplier_id TEXT NOT NULL,
+    customer_id TEXT NOT NULL,
+    bank_account_id TEXT NOT NULL,
+    status TEXT DEFAULT 'draft',
+    issue_date DATE NOT NULL,
+    due_date DATE NOT NULL,
+    paid_date DATE,
+    taxable_date DATE,
+    payment_method TEXT DEFAULT 'bank_transfer',
+    variable_symbol TEXT,
+    currency TEXT DEFAULT 'CZK',
+    exchange_rate REAL DEFAULT 1.0,
+    subtotal REAL DEFAULT 0,
+    vat_total REAL DEFAULT 0,
+    total REAL DEFAULT 0,
+    notes TEXT,
+    internal_notes TEXT,
+    language TEXT DEFAULT 'cs',
+    pdf_path TEXT,
+    template_id TEXT DEFAULT 'default',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (supplier_id) REFERENCES suppliers(id),
+    FOREIGN KEY (customer_id) REFERENCES customers(id),
+    FOREIGN KEY (bank_account_id) REFERENCES bank_accounts(id)
+);
+
+-- Detect corruption: if updated_at doesn't look like a datetime (YYYY-MM-DD...),
+-- swap the three columns back. Otherwise keep as-is.
+INSERT INTO invoices_repair (id, invoice_number, supplier_id, customer_id, bank_account_id,
+    status, issue_date, due_date, paid_date, taxable_date, payment_method, variable_symbol,
+    currency, exchange_rate, subtotal, vat_total, total, notes, internal_notes, language,
+    pdf_path, template_id, created_at, updated_at)
+SELECT id, invoice_number, supplier_id, customer_id, bank_account_id,
+    status, issue_date, due_date, paid_date, taxable_date, payment_method, variable_symbol,
+    currency, exchange_rate, subtotal, vat_total, total, notes, internal_notes, language,
+    pdf_path,
+    CASE WHEN updated_at NOT LIKE '____-__-__%' THEN updated_at ELSE template_id END,
+    CASE WHEN updated_at NOT LIKE '____-__-__%' THEN template_id ELSE created_at END,
+    CASE WHEN updated_at NOT LIKE '____-__-__%' THEN created_at ELSE updated_at END
+FROM invoices;
+
+DROP TABLE invoices;
+ALTER TABLE invoices_repair RENAME TO invoices;
+
+CREATE UNIQUE INDEX idx_invoices_supplier_number ON invoices(supplier_id, invoice_number);
+CREATE INDEX idx_invoices_status ON invoices(status);
+CREATE INDEX idx_invoices_customer ON invoices(customer_id);
+CREATE INDEX idx_invoices_issue_date ON invoices(issue_date);
+
+PRAGMA foreign_keys = ON;

--- a/internal/service/pdf.go
+++ b/internal/service/pdf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/johnfercher/maroto/v2"
 	"github.com/johnfercher/maroto/v2/pkg/config"
@@ -61,7 +62,8 @@ func (s *PDFService) GenerateInvoice(data *InvoiceData, templateCode string, opt
 	}
 
 	year := data.Invoice.IssueDate.Year()
-	yearDir := filepath.Join(s.pdfDir, fmt.Sprintf("%d", year))
+	supplierDir := sanitizeDirName(data.Supplier.Name)
+	yearDir := filepath.Join(s.pdfDir, supplierDir, fmt.Sprintf("%d", year))
 	if err := os.MkdirAll(yearDir, 0755); err != nil {
 		return "", err
 	}
@@ -72,4 +74,16 @@ func (s *PDFService) GenerateInvoice(data *InvoiceData, templateCode string, opt
 	}
 
 	return pdfPath, nil
+}
+
+func sanitizeDirName(name string) string {
+	replacer := strings.NewReplacer(
+		"/", "_", "\\", "_", ":", "_", "*", "_",
+		"?", "_", "\"", "_", "<", "_", ">", "_", "|", "_",
+	)
+	result := strings.TrimSpace(replacer.Replace(name))
+	if result == "" {
+		return "default"
+	}
+	return result
 }


### PR DESCRIPTION
- Change invoice_number UNIQUE constraint from global to per-supplier (composite index on supplier_id + invoice_number)
- Add repair migration (005) to fix column data corruption from broken 004 that used positional SELECT * with mismatched column order
- Wrap table recreation migrations with PRAGMA foreign_keys = OFF to prevent CASCADE deletes on invoice_items
- Add supplier name subdirectory to PDF paths to avoid file collisions when two suppliers share the same invoice prefix
- Return HTTP 409 instead of 500 for duplicate invoice number on create